### PR TITLE
Updated ".has-flex-end-items"

### DIFF
--- a/sass/bulma-utilities.sass
+++ b/sass/bulma-utilities.sass
@@ -243,7 +243,7 @@ $local-colors: 0
 
 .has-flex-end-items
 	display: flex
-	align-items: end
+	align-items: flex-end
 
 //cursor utilities
 .is-clickable


### PR DESCRIPTION
Changed align-items from end to flex-end. This will prevent the following warning using postcss-loader:

Module Warning (from ./node_modules/postcss-loader/src/index.js):
Warning
(1464:3) end value has mixed support, consider using flex-end instead